### PR TITLE
Modified library to work with Tricore Ifx Qspi driver

### DIFF
--- a/EVE_target/EVE_target_Tricore_Tasking.h
+++ b/EVE_target/EVE_target_Tricore_Tasking.h
@@ -39,6 +39,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define EVE_TARGET_TRICORE_H
 
 #if !defined (ARDUINO)
+#define __TASKING__   // TODO: REMOVE!!!!!!!
 #if defined(__TASKING__)
 
 #include <stdint.h>
@@ -76,15 +77,18 @@ static inline void spi_transmit(uint8_t data)
 {
     (void) data;
     __nop();
+    // Not supported with IfxQspi driver out of the box!!  Maybe with MCAL?
 //    SPI_ReceiveByte(data);
 }
 
 static inline void spi_transmit_32(uint32_t data)
 {
-    spi_transmit((uint8_t)(data & 0x000000ffUL));
-    spi_transmit((uint8_t)(data >> 8U));
-    spi_transmit((uint8_t)(data >> 16U));
-    spi_transmit((uint8_t)(data >> 24U));
+    g_qspi.spiBuffers.spiMasterTxBuffer[0]=(uint8_t)(data & 0xff);
+    g_qspi.spiBuffers.spiMasterTxBuffer[1]=(uint8_t)((data >> 8) & 0xff);
+    g_qspi.spiBuffers.spiMasterTxBuffer[2]=(uint8_t)((data >> 16) & 0xff);
+    g_qspi.spiBuffers.spiMasterTxBuffer[3]=(uint8_t)((data >> 24) & 0xff);
+    IfxQspi_SpiMaster_exchange(&g_qspi.spiMasterChannel, &g_qspi.spiBuffers.spiMasterTxBuffer[0], &g_qspi.spiBuffers.spiMasterRxBuffer[0], 4);
+    while(IfxQspi_SpiMaster_getStatus(&g_qspi.spiMasterChannel) == SpiIf_Status_busy) {}
 }
 
 /* spi_transmit_burst() is only used for cmd-FIFO commands */
@@ -98,12 +102,118 @@ static inline uint8_t spi_receive(uint8_t data)
 {
     (void) data;
     return (0);
+    // Not supported with IfxQspi driver out of the box!!  Maybe with MCAL?
 //    return (SPI_ReceiveByte(data));
 }
 
 static inline uint8_t fetch_flash_byte(const uint8_t *p_data)
 {
     return (*p_data);
+}
+
+static inline void EVE_start_burst()
+{
+    g_qspi.spiBuffers.spiMasterTxBuffer[0]=0xB0U; /* high-byte of REG_CMDB_WRITE + MEM_WRITE */
+    g_qspi.spiBuffers.spiMasterTxBuffer[1]=0x25U; /* middle-byte of REG_CMDB_WRITE */
+    g_qspi.spiBuffers.spiMasterTxBuffer[2]=0x78U; /* low-byte of REG_CMDB_WRITE */
+    IfxQspi_SpiMaster_exchange(&g_qspi.spiMasterChannel, &g_qspi.spiBuffers.spiMasterTxBuffer[0], &g_qspi.spiBuffers.spiMasterRxBuffer[0], 3);
+    while(IfxQspi_SpiMaster_getStatus(&g_qspi.spiMasterChannel) == SpiIf_Status_busy) {}
+}
+
+static inline void EVE_host_command(uint8_t HCMD, uint8_t param)
+{
+    g_qspi.spiBuffers.spiMasterTxBuffer[0]=HCMD;
+    g_qspi.spiBuffers.spiMasterTxBuffer[1]=param;
+    g_qspi.spiBuffers.spiMasterTxBuffer[2]=0x00;
+    IfxQspi_SpiMaster_exchange(&g_qspi.spiMasterChannel, &g_qspi.spiBuffers.spiMasterTxBuffer[0], &g_qspi.spiBuffers.spiMasterRxBuffer[0], 3);
+    while(IfxQspi_SpiMaster_getStatus(&g_qspi.spiMasterChannel) == SpiIf_Status_busy) {}
+}
+
+static inline void spi_wr32(uint32_t address, uint32_t parameter)
+{
+    g_qspi.spiBuffers.spiMasterTxBuffer[0]=((address >> 16) | 0x80); // RAM_REG = 0x302000 and high bit is set - result always 0xB0;
+    g_qspi.spiBuffers.spiMasterTxBuffer[1]=(uint8_t)(address >> 8); // Next byte of the register address;
+    g_qspi.spiBuffers.spiMasterTxBuffer[2]=(uint8_t)address; // Low byte of register address - usually just the 1 byte offset;
+    g_qspi.spiBuffers.spiMasterTxBuffer[3]=(uint8_t)(parameter & 0xff);
+    g_qspi.spiBuffers.spiMasterTxBuffer[4]=(uint8_t)((parameter >> 8) & 0xff);
+    g_qspi.spiBuffers.spiMasterTxBuffer[5]=(uint8_t)((parameter >> 16) & 0xff);
+    g_qspi.spiBuffers.spiMasterTxBuffer[6]=(uint8_t)((parameter >> 24) & 0xff);
+    IfxQspi_SpiMaster_exchange(&g_qspi.spiMasterChannel, &g_qspi.spiBuffers.spiMasterTxBuffer[0], &g_qspi.spiBuffers.spiMasterRxBuffer[0], 7);
+    while(IfxQspi_SpiMaster_getStatus(&g_qspi.spiMasterChannel) == SpiIf_Status_busy) {}
+}
+
+static inline void spi_wr16(uint32_t address, uint16_t parameter)
+{
+    g_qspi.spiBuffers.spiMasterTxBuffer[0]=((address >> 16) | 0x80); // RAM_REG = 0x302000 and high bit is set - result always 0xB0;
+    g_qspi.spiBuffers.spiMasterTxBuffer[1]=(uint8_t)(address >> 8); // Next byte of the register address;
+    g_qspi.spiBuffers.spiMasterTxBuffer[2]=(uint8_t)address; // Low byte of register address - usually just the 1 byte offset;
+    g_qspi.spiBuffers.spiMasterTxBuffer[3]=(uint8_t)(parameter & 0xff);
+    g_qspi.spiBuffers.spiMasterTxBuffer[4]=(uint8_t)((parameter >> 8) & 0xff);
+    IfxQspi_SpiMaster_exchange(&g_qspi.spiMasterChannel, &g_qspi.spiBuffers.spiMasterTxBuffer[0], &g_qspi.spiBuffers.spiMasterRxBuffer[0], 5);
+    while(IfxQspi_SpiMaster_getStatus(&g_qspi.spiMasterChannel) == SpiIf_Status_busy) {}
+}
+
+static inline void spi_wr8(uint32_t address, uint8_t parameter)
+{
+    g_qspi.spiBuffers.spiMasterTxBuffer[0]=((address >> 16) | 0x80); // RAM_REG = 0x302000 and high bit is set - result always 0xB0;
+    g_qspi.spiBuffers.spiMasterTxBuffer[1]=(uint8_t)(address >> 8); // Next byte of the register address;
+    g_qspi.spiBuffers.spiMasterTxBuffer[2]=(uint8_t)address; // Low byte of register address - usually just the 1 byte offset;
+    g_qspi.spiBuffers.spiMasterTxBuffer[3]=(uint8_t)(parameter & 0xff);
+    IfxQspi_SpiMaster_exchange(&g_qspi.spiMasterChannel, &g_qspi.spiBuffers.spiMasterTxBuffer[0], &g_qspi.spiBuffers.spiMasterRxBuffer[0], 4);
+    while(IfxQspi_SpiMaster_getStatus(&g_qspi.spiMasterChannel) == SpiIf_Status_busy) {}
+}
+
+static inline uint32_t spi_rd32(uint32_t address)
+{
+    uint32_t Data32;
+    g_qspi.spiBuffers.spiMasterTxBuffer[0]=(address >> 16) & 0x3F; // RAM_REG = 0x302000 and high bit is set - result always 0xB0;
+    g_qspi.spiBuffers.spiMasterTxBuffer[1]=(address >> 8) & 0xff; // Next byte of the register address;
+    g_qspi.spiBuffers.spiMasterTxBuffer[2]=address & 0xff; // Low byte of register address - usually just the 1 byte offset;
+    g_qspi.spiBuffers.spiMasterTxBuffer[3]=0x00;
+    g_qspi.spiBuffers.spiMasterTxBuffer[4]=0x00;
+    g_qspi.spiBuffers.spiMasterTxBuffer[5]=0x00;
+    g_qspi.spiBuffers.spiMasterTxBuffer[6]=0x00;
+    g_qspi.spiBuffers.spiMasterTxBuffer[7]=0x00;
+    IfxQspi_SpiMaster_exchange(&g_qspi.spiMasterChannel, &g_qspi.spiBuffers.spiMasterTxBuffer[0], &g_qspi.spiBuffers.spiMasterRxBuffer[0], 8);
+    while(IfxQspi_SpiMaster_getStatus(&g_qspi.spiMasterChannel) == SpiIf_Status_busy) {}
+
+    Data32 = g_qspi.spiBuffers.spiMasterRxBuffer[4] +
+            ((uint32_t)g_qspi.spiBuffers.spiMasterRxBuffer[5] << 8) +
+            ((uint32_t)g_qspi.spiBuffers.spiMasterRxBuffer[6] << 16) +
+            ((uint32_t)g_qspi.spiBuffers.spiMasterRxBuffer[7] << 24);
+
+    return (Data32);
+}
+
+static inline uint16_t spi_rd16(uint32_t address)
+{
+    uint16_t Data16;
+    g_qspi.spiBuffers.spiMasterTxBuffer[0]=((address >> 16) & 0x3F); // RAM_REG = 0x302000 and high bit is set - result always 0xB0;
+    g_qspi.spiBuffers.spiMasterTxBuffer[1]=((address >> 8) & 0xff); // Next byte of the register address;
+    g_qspi.spiBuffers.spiMasterTxBuffer[2]=address & 0xff; // Low byte of register address - usually just the 1 byte offset;
+    g_qspi.spiBuffers.spiMasterTxBuffer[3]=0x00;
+    g_qspi.spiBuffers.spiMasterTxBuffer[4]=0x00;
+    g_qspi.spiBuffers.spiMasterTxBuffer[5]=0x00;
+    IfxQspi_SpiMaster_exchange(&g_qspi.spiMasterChannel, &g_qspi.spiBuffers.spiMasterTxBuffer[0], &g_qspi.spiBuffers.spiMasterRxBuffer[0], 6);
+    while(IfxQspi_SpiMaster_getStatus(&g_qspi.spiMasterChannel) == SpiIf_Status_busy) {}
+    Data16 = g_qspi.spiBuffers.spiMasterRxBuffer[4] +
+           ((uint32_t)g_qspi.spiBuffers.spiMasterRxBuffer[5] << 8);
+
+    return (Data16);
+}
+
+static inline uint8_t spi_rd8(uint32_t address)
+{
+    uint8_t Data8;
+    g_qspi.spiBuffers.spiMasterTxBuffer[0]=((address >> 16) & 0x3F);
+    g_qspi.spiBuffers.spiMasterTxBuffer[1]=((address >> 8) & 0xff);
+    g_qspi.spiBuffers.spiMasterTxBuffer[2]=(address & 0xff);
+    g_qspi.spiBuffers.spiMasterTxBuffer[3]=0x00;
+    g_qspi.spiBuffers.spiMasterTxBuffer[4]=0x00;
+    IfxQspi_SpiMaster_exchange(&g_qspi.spiMasterChannel, &g_qspi.spiBuffers.spiMasterTxBuffer[0], &g_qspi.spiBuffers.spiMasterRxBuffer[0], 5);
+    while(IfxQspi_SpiMaster_getStatus(&g_qspi.spiMasterChannel) == SpiIf_Status_busy) {}
+    Data8 = g_qspi.spiBuffers.spiMasterRxBuffer[4];
+    return (Data8);
 }
 
 #endif /* __TASKING__ */


### PR DESCRIPTION
The Ifx Qspi driver doesn't directly support the manual control of the CS pin.  So needed to change some SPI read/write functions to send all at once rather than one byte at a time.

- change spi_transmit_32 to use IfxQspi_SpiMaster_exchange()
- change all the EVE_memReadXX()/WriteXX() functions to call functions using IfxQspi_SpiMaster_exchange()
- change EVE_cmdWrite() to call a function using IfxQspi_SpiMaster_exchange()

3 things still needed external to these mods:
1) spiMasterChannelConfig.base.mode.autoCS = 0; // use manual chip select functions
2) Modify iLLD/TC39B/Tricore/Qspi/SpiMaster/IfxQspi_SpiMaster.c:
   - comment out contents of IfxQspi_SpiMaster_activateSlso()
   - comment out contents of IfxQspi_SpiMaster_deactivateSlso()
3) Need to use the burst commands always, or confirm that spi_transmit() is not used.